### PR TITLE
Pass bound function and not object method (no this)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -22,7 +22,7 @@ const bot = new Bot({
 bot.join(config.keys, (err) => {
   if (err) throw err
   if (argv.port || config.port) {
-    const server = createServer(bot.say)
+    const server = createServer(bot.say.bind(bot))
 
     server.listen(config.port, () => {
       console.log('Listening on', config.port)


### PR DESCRIPTION
Passing `bot.say` doesn't work since `bot.say()` will use `this` inside the method.

As an example:

```js
const events = require('events')

class Dude extends events.EventEmitter {
  constructor () {
    super()
    this.foo = 'bar'
  }

  say () {
    console.log('this.foo =', this.foo)
  }
}

const dude = new Dude()

dude.say() // this.foo = bar

function sayDude (fn) {
  fn()
}

sayDude(dude.say.bind(dude)) // this.foo = bar
sayDude(dude.say) // crashes since no this is bound
```